### PR TITLE
Feature/fraction digits

### DIFF
--- a/schema/dataset.schema.json
+++ b/schema/dataset.schema.json
@@ -82,10 +82,7 @@
         },
         "label": {
           "description": "Label for Variable",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "length": {
           "description": "Length for Variable",

--- a/typescript/dataset.ts
+++ b/typescript/dataset.ts
@@ -30,7 +30,7 @@ export interface ItemDescription {
      *
      * @TJS-type string
      */
-    label: string|null;
+    label: string;
     /**
      * Data type for Variable
      *


### PR DESCRIPTION
This PR makes the following changes to the schema ([ODMv2 meeting notes:](https://wiki.cdisc.org/display/XMLT/2022-03-16+Team+Meeting+notes))
- Added fractionDigits as an optional item attribute
- Made type and label required attributes for items
- Allow null for optional attributes (length, fractionDigits)
- Add decimal and boolean to the item types.
- implemented itemGroupDataSeq by requiring that the first value for a record is a number:

`"itemData": [
          [1, "MyStudy", "001", "DM", 56],
          [2, "MyStudy", "002", "DM", 26],
          ...
   ]
`

This will also mean that the first item description needs to  describe itemGroupDataSeq:

`"items": [
    {
        "OID": "ITEMGROUPDATASEQ",
        "name": "ITEMGROUPDATASEQ",
        "label": "Record Identifier",
        "type": "integer"
    },
`

See attached example.
[dd_example.txt](https://github.com/cdisc-org/DataExchange-DatasetJson/files/8307071/dd_example.txt)

