### PR TITLE
Fixed npm script to use standard syntax for all OS compatibilty

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "schema": "./node_modules/.bin/ts-json-schema-generator --path 'dataset.ts' --type 'DatasetJson' > ../schema/dataset.schema.json"
+    "schema": "npx ts-json-schema-generator --path dataset.ts --type DatasetJson > ../schema/dataset.schema.json && echo JSON Schema generated successfully! || echo JSON Schema generation Failed."
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Failed to generate JSON schema dataset.schema.json in Windows OS.

In Unix-like systems (such as Linux or macOS) the npm run schema working fine but for windows it's not working because of npm script.
![image](https://github.com/cdisc-org/DataExchange-DatasetJson/assets/91017111/b458817f-8adf-4433-895a-fe76e796f00d)

Windows System Incompatiblity
![image](https://github.com/cdisc-org/DataExchange-DatasetJson/assets/91017111/f21275d2-79f3-4ac3-845e-6ef5105b1812)

Modified the npm script to use the appropriate syntax that is compatible with all type of OS systems and implemented better error handeling.
![image](https://github.com/cdisc-org/DataExchange-DatasetJson/assets/91017111/b1e42ef4-54c3-438c-b236-dab8b5b4ec7e)
